### PR TITLE
test: add navbar rendering test

### DIFF
--- a/src/FrontEnd/package.json
+++ b/src/FrontEnd/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -25,6 +26,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.2.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
+    "vitest": "^2.1.1",
+    "jsdom": "^24.0.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.34.1",
     "vite": "^7.0.0"

--- a/src/FrontEnd/src/Components/Navbar.test.tsx
+++ b/src/FrontEnd/src/Components/Navbar.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
+import FSNavbar from './Navbar';
+
+describe('FSNavbar', () => {
+  it('renders navigation links and uses client-side routing', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <FSNavbar />
+      </MemoryRouter>
+    );
+
+    const links = [
+      { name: /firestarters/i, path: '/' },
+      { name: /home/i, path: '/' },
+      { name: /events/i, path: '/events' },
+      { name: /contact/i, path: '/contact' },
+    ];
+
+    for (const { name, path } of links) {
+      const link = screen.getByRole('link', { name });
+      expect(link).toBeTruthy();
+      expect(link.getAttribute('href')).toBe(path);
+      await user.click(link);
+      expect(window.location.pathname).toBe(path);
+    }
+  });
+});

--- a/src/FrontEnd/vite.config.ts
+++ b/src/FrontEnd/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## Summary
- add vitest and testing library tooling
- configure Vite test environment
- add FSNavbar tests for navigation links

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689866f1f688832496798d0ae310e406